### PR TITLE
Remove indexes, fix ens name

### DIFF
--- a/ethtx/providers/semantic_providers/database.py
+++ b/ethtx/providers/semantic_providers/database.py
@@ -14,10 +14,8 @@ import logging
 from typing import Dict, Optional
 
 import bson
-from pymongo import TEXT
 from pymongo.cursor import Cursor
 from pymongo.database import Database as MongoDatabase
-from pymongo.errors import OperationFailure
 
 from .base import ISemanticsDatabase
 from .const import MongoCollections
@@ -107,13 +105,3 @@ class MongoSemanticsDatabase(ISemanticsDatabase):
     def _init_collections(self) -> None:
         for mongo_collection in MongoCollections:
             self.__setattr__(f"_{mongo_collection}", self._db[mongo_collection])
-
-            if mongo_collection == "signatures":
-                try:
-                    self._signatures.create_index(
-                        [("signature_hash", TEXT), ("name", TEXT)],
-                        background=True,
-                        unique=False,
-                    )
-                except OperationFailure as e:
-                    log.warning(e)

--- a/ethtx/providers/semantic_providers/repository.py
+++ b/ethtx/providers/semantic_providers/repository.py
@@ -151,9 +151,10 @@ class SemanticsRepository:
                     transformations,
                 )
 
-            name = address
-            if not raw_address_semantics["is_contract"]:
-                name = self._web3provider.ens.name(address)
+            name = raw_address_semantics.get("name", address)
+            if name == address and not raw_address_semantics["is_contract"]:
+                ns_name = self._web3provider.ens.name(address)
+                name = ns_name if ns_name else name
 
             address_semantics = AddressSemantics(
                 chain_id,


### PR DESCRIPTION
- Removed indexes -incompatibility with macOS.
- ENS name fix. The contract name was decoded incorrectly, because `None` (unresolved) address value was overwriting the correct one.