### PR TITLE
Bump python to 3.9

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -21,4 +21,4 @@ pytest-mock ="==3.6.1"
 pre-commit = "*"
 
 [requires]
-python_version = "3.8"
+python_version = "3.9"


### PR DESCRIPTION
Python 3.9 is official in ubuntu repos and 3.8 is gone, we can safely bump it up