### PR TITLE
Fix `DecodedTransactionMetadata` model, fix types, update pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,9 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: 19.3b0
+    rev: 22.3.0
     hooks:
       - id: black
-        language_version: python3.8
+        language_version: python3.9
         name: Backend:black
         alias: backend-black
 

--- a/ethtx/decoders/abi/transfers.py
+++ b/ethtx/decoders/abi/transfers.py
@@ -50,7 +50,10 @@ class ABITransfersDecoder(ABISubmoduleAbc):
         for event in events:
 
             # this is a signature of Transfer event valid for ERC20 and ERC721
-            if event.event_signature == "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef":
+            if (
+                event.event_signature
+                == "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+            ):
 
                 from_address = event.parameters[0].value
                 from_name = self._repository.get_address_label(

--- a/ethtx/decoders/semantic/decoder.py
+++ b/ethtx/decoders/semantic/decoder.py
@@ -27,7 +27,7 @@ from ethtx.models.decoded_model import (
     DecodedCall,
     Proxy,
 )
-from ethtx.models.objects_model import BlockMetadata, TransactionMetadata
+from ethtx.models.objects_model import BlockMetadata
 
 
 class SemanticDecoder(ISemanticDecoder):

--- a/ethtx/decoders/semantic/decoder.py
+++ b/ethtx/decoders/semantic/decoder.py
@@ -59,7 +59,7 @@ class SemanticDecoder(ISemanticDecoder):
     def decode_metadata(
         self,
         block_metadata: BlockMetadata,
-        tx_metadata: TransactionMetadata,
+        tx_metadata: DecodedTransactionMetadata,
         chain_id: str,
     ) -> DecodedTransactionMetadata:
         return SemanticMetadataDecoder(repository=self.repository).decode(

--- a/ethtx/decoders/semantic/metadata.py
+++ b/ethtx/decoders/semantic/metadata.py
@@ -11,7 +11,7 @@
 #  limitations under the License.
 
 from ethtx.models.decoded_model import DecodedTransactionMetadata, AddressInfo
-from ethtx.models.objects_model import BlockMetadata, TransactionMetadata
+from ethtx.models.objects_model import BlockMetadata
 from .abc import SemanticSubmoduleAbc
 
 

--- a/ethtx/decoders/semantic/metadata.py
+++ b/ethtx/decoders/semantic/metadata.py
@@ -21,7 +21,7 @@ class SemanticMetadataDecoder(SemanticSubmoduleAbc):
     def decode(
         self,
         block_metadata: BlockMetadata,
-        tx_metadata: TransactionMetadata,
+        tx_metadata: DecodedTransactionMetadata,
         chain_id: str,
     ) -> DecodedTransactionMetadata:
         """Semantically decode metadata."""

--- a/ethtx/models/decoded_model.py
+++ b/ethtx/models/decoded_model.py
@@ -33,6 +33,8 @@ class DecodedTransactionMetadata(BaseModel):
     block_hash: Optional[str]
     timestamp: Optional[datetime]
     gas_price: Optional[int]
+    from_address: Optional[str]
+    to_address: Optional[str]
     sender: Optional[AddressInfo]
     receiver: Optional[AddressInfo]
     tx_index: int
@@ -98,7 +100,7 @@ class DecodedBalance(BaseModel):
 
 class DecodedTransaction(BaseModel):
     block_metadata: BlockMetadata
-    metadata: TransactionMetadata
+    metadata: DecodedTransactionMetadata
     events: List[DecodedEvent]
     calls: Optional[DecodedCall]
     transfers: List[DecodedTransfer]

--- a/ethtx/models/decoded_model.py
+++ b/ethtx/models/decoded_model.py
@@ -16,7 +16,7 @@ from datetime import datetime
 from typing import List, Any, Optional
 
 from ethtx.models.base_model import BaseModel
-from ethtx.models.objects_model import BlockMetadata, TransactionMetadata
+from ethtx.models.objects_model import BlockMetadata
 from ethtx.models.semantics_model import AddressSemantics, ERC20Semantics
 
 

--- a/ethtx/providers/web3_provider.py
+++ b/ethtx/providers/web3_provider.py
@@ -338,7 +338,9 @@ class Web3Provider(NodeDataProvider):
     def guess_erc20_token(self, contract_address, chain_id: Optional[str] = None):
         chain = self._get_node_connection(chain_id)
 
-        byte_code = chain.eth.get_code(Web3.toChecksumAddress(contract_address[-40:])).hex()
+        byte_code = chain.eth.get_code(
+            Web3.toChecksumAddress(contract_address[-40:])
+        ).hex()
 
         if all(
             "63" + signature[2:] in byte_code

--- a/tests/models/decoded_model_test.py
+++ b/tests/models/decoded_model_test.py
@@ -180,7 +180,7 @@ class TestDecodedModels:
 
         t = DecodedTransaction(
             block_metadata=ObjectModelMock.BLOCK_METADATA,
-            metadata=ObjectModelMock.TRANSACTION_METADATA,
+            metadata=DecodedModelMock.DECODED_TRANSACTION_METADATA,
             events=[de],
             calls=dc,
             transfers=[dt],
@@ -188,7 +188,7 @@ class TestDecodedModels:
         )
 
         assert t.block_metadata == ObjectModelMock.BLOCK_METADATA
-        assert t.metadata == ObjectModelMock.TRANSACTION_METADATA
+        assert t.metadata == DecodedModelMock.DECODED_TRANSACTION_METADATA
         assert t.events == [de]
         assert t.calls == dc
         assert t.transfers == [dt]

--- a/tests/models/mock.py
+++ b/tests/models/mock.py
@@ -2,7 +2,7 @@ import datetime
 
 import pytest
 
-from ethtx.models.decoded_model import AddressInfo, Argument
+from ethtx.models.decoded_model import AddressInfo, Argument, DecodedTransactionMetadata
 from ethtx.models.objects_model import BlockMetadata, TransactionMetadata, Call, Event
 from ethtx.models.semantics_model import ParameterSemantics, ContractSemantics
 
@@ -22,6 +22,20 @@ def patch_datetime_now(monkeypatch):
 class DecodedModelMock:
     ADDRESS_INFO: AddressInfo = AddressInfo(address="address", name="name")
     ARGUMENT: Argument = Argument(name="name", type="type", value=1)
+    DECODED_TRANSACTION_METADATA: DecodedTransactionMetadata = (
+        DecodedTransactionMetadata(
+            tx_hash="0x",
+            block_number=1,
+            gas_price=2,
+            from_address="0xa",
+            to_address="0xb",
+            tx_index=3,
+            tx_value=4,
+            gas_limit=5,
+            gas_used=1,
+            success=False,
+        )
+    )
 
 
 class ObjectModelMock:


### PR DESCRIPTION
- added optional fields `from_address` and `to_address` to DecodedTransactionMetadata model
- updated black `pre-commit` version
- fixed wrong transaction metadata types
- updated tests