### PR TITLE
More flexible dependencies, no cursor timeout, cache 4bytes

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ eth-utils = "==1.10.0"
 eth-rlp = "==0.2.1"
 pydantic = ">=1.8.0"
 python-dotenv = "*"
+requests_cache = "*"
 
 [dev-packages]
 black = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -5,22 +5,22 @@ name = "pypi"
 
 [packages]
 toml = "*"
-pymongo = ">=3.12.0"
-dnspython = ">=2.2.0"
-mongoengine = "==0.23.1"
-mongomock = "==3.23.0"
+pymongo = ">=3.10.0"
+dnspython = ">=2.0.0"
+mongoengine = "*"
+mongomock = "*"
 web3 = "==5.26.0"
 eth-account = "==0.5.6"
 eth-utils = "==1.10.0"
 eth-rlp = "==0.2.1"
-pydantic = ">=1.9.0"
+pydantic = ">=1.8.0"
 python-dotenv = "*"
 
 [dev-packages]
 black = "*"
-pytest = ">=6.2.5"
-pytest-cov =">=3.0.0"
-pytest-mock =">=3.6.1"
+pytest = ">=6.0.0"
+pytest-cov ="*"
+pytest-mock ="*"
 pre-commit = "*"
 
 [requires]

--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 toml = "*"
-pymongo = ">=3.10.0"
+pymongo = ">=3.10.0,<4.0"
 dnspython = ">=2.0.0"
 mongoengine = "*"
 mongomock = "*"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The package needs a few external resources, defined in `EthTxConfig` object:
    the `debug` option ON
 2. **Etherscan API key** - required to get the source code and ABI for smart contracts used in transaction
 3. (Optional) **MongoDB database** - required to store smart contracts' ABI and semantics used in the decoding process.
-   If you don't want to setup permanent database, you can enter `mongomock://localhost`, then in-memory mongo will be
+   If you don't want to setup permanent database, you can enter `mongomock://localhost/ethtx`, then in-memory mongo will be
    set up that discards all data with every run.
 
 ## Getting started

--- a/ethtx/providers/semantic_providers/database.py
+++ b/ethtx/providers/semantic_providers/database.py
@@ -39,10 +39,9 @@ class MongoSemanticsDatabase(ISemanticsDatabase):
     def get_collection_count(self) -> int:
         return len(self._db.list_collection_names())
 
-    @cache
     def get_address_semantics(
         self, chain_id, address, *, cursor_timeout_millis=None
-    ) -> Cursor:
+    ) -> Dict:
         _id = f"{chain_id}-{address}"
 
         return self._addresses.find_one(
@@ -51,7 +50,6 @@ class MongoSemanticsDatabase(ISemanticsDatabase):
             **self._cursor_properties(cursor_timeout_millis=cursor_timeout_millis),
         )
 
-    @cache
     def get_signature_semantics(
         self, signature_hash: str, *, cursor_timeout_millis=None
     ) -> Cursor:
@@ -76,10 +74,7 @@ class MongoSemanticsDatabase(ISemanticsDatabase):
         inserted_signature = self._signatures.insert_one(signature)
         return inserted_signature.inserted_id
 
-    @cache
-    def get_contract_semantics(
-        self, code_hash, *, cursor_timeout_millis=None
-    ) -> Cursor:
+    def get_contract_semantics(self, code_hash, *, cursor_timeout_millis=None) -> Dict:
         """Contract hashes are always the same, no mather what chain we use, so there is no need
         to use chain_id"""
         return self._contracts.find_one(

--- a/ethtx/providers/semantic_providers/database.py
+++ b/ethtx/providers/semantic_providers/database.py
@@ -39,6 +39,7 @@ class MongoSemanticsDatabase(ISemanticsDatabase):
     def get_collection_count(self) -> int:
         return len(self._db.list_collection_names())
 
+    @cache
     def get_address_semantics(
         self, chain_id, address, *, cursor_timeout_millis=None
     ) -> Dict:
@@ -50,6 +51,7 @@ class MongoSemanticsDatabase(ISemanticsDatabase):
             **self._cursor_properties(cursor_timeout_millis=cursor_timeout_millis),
         )
 
+    @cache
     def get_signature_semantics(
         self, signature_hash: str, *, cursor_timeout_millis=None
     ) -> Cursor:
@@ -74,6 +76,7 @@ class MongoSemanticsDatabase(ISemanticsDatabase):
         inserted_signature = self._signatures.insert_one(signature)
         return inserted_signature.inserted_id
 
+    @cache
     def get_contract_semantics(self, code_hash, *, cursor_timeout_millis=None) -> Dict:
         """Contract hashes are always the same, no mather what chain we use, so there is no need
         to use chain_id"""

--- a/ethtx/providers/semantic_providers/database.py
+++ b/ethtx/providers/semantic_providers/database.py
@@ -40,13 +40,25 @@ class MongoSemanticsDatabase(ISemanticsDatabase):
         return len(self._db.list_collection_names())
 
     @cache
-    def get_address_semantics(self, chain_id, address) -> Optional[Dict]:
+    def get_address_semantics(
+        self, chain_id, address, *, cursor_timeout_millis=None
+    ) -> Optional[Dict]:
         _id = f"{chain_id}-{address}"
-        return self._addresses.find_one({"_id": _id}, {"_id": 0})
+
+        return self._addresses.find_one(
+            {"_id": _id},
+            {"_id": 0},
+            **self._cursor_properties(cursor_timeout_millis=cursor_timeout_millis),
+        )
 
     @cache
-    def get_signature_semantics(self, signature_hash: str) -> Cursor:
-        return self._signatures.find({"signature_hash": signature_hash})
+    def get_signature_semantics(
+        self, signature_hash: str, *, cursor_timeout_millis=None
+    ) -> Cursor:
+        return self._signatures.find(
+            {"signature_hash": signature_hash},
+            **self._cursor_properties(cursor_timeout_millis=cursor_timeout_millis),
+        )
 
     def insert_signature(
         self, signature: dict, update_if_exist=False
@@ -65,10 +77,14 @@ class MongoSemanticsDatabase(ISemanticsDatabase):
         return inserted_signature.inserted_id
 
     @cache
-    def get_contract_semantics(self, code_hash):
+    def get_contract_semantics(self, code_hash, *, cursor_timeout_millis=None):
         """Contract hashes are always the same, no mather what chain we use, so there is no need
         to use chain_id"""
-        return self._contracts.find_one({"_id": code_hash}, {"_id": 0})
+        return self._contracts.find_one(
+            {"_id": code_hash},
+            {"_id": 0},
+            **self._cursor_properties(cursor_timeout_millis=cursor_timeout_millis),
+        )
 
     def insert_contract(
         self, contract, update_if_exist=False
@@ -105,6 +121,13 @@ class MongoSemanticsDatabase(ISemanticsDatabase):
 
         inserted_address = self._addresses.insert_one(address_with_id)
         return inserted_address.inserted_id
+
+    def _cursor_properties(self, cursor_timeout_millis=None) -> Dict:
+        return (
+            {"max_time_ms": cursor_timeout_millis}
+            if cursor_timeout_millis
+            else {"no_cursor_timeout": True}
+        )
 
     def _init_collections(self) -> None:
         for mongo_collection in MongoCollections:

--- a/ethtx/providers/semantic_providers/database.py
+++ b/ethtx/providers/semantic_providers/database.py
@@ -42,7 +42,7 @@ class MongoSemanticsDatabase(ISemanticsDatabase):
     @cache
     def get_address_semantics(
         self, chain_id, address, *, cursor_timeout_millis=None
-    ) -> Optional[Dict]:
+    ) -> Cursor:
         _id = f"{chain_id}-{address}"
 
         return self._addresses.find_one(
@@ -77,7 +77,9 @@ class MongoSemanticsDatabase(ISemanticsDatabase):
         return inserted_signature.inserted_id
 
     @cache
-    def get_contract_semantics(self, code_hash, *, cursor_timeout_millis=None):
+    def get_contract_semantics(
+        self, code_hash, *, cursor_timeout_millis=None
+    ) -> Cursor:
         """Contract hashes are always the same, no mather what chain we use, so there is no need
         to use chain_id"""
         return self._contracts.find_one(
@@ -122,7 +124,7 @@ class MongoSemanticsDatabase(ISemanticsDatabase):
         inserted_address = self._addresses.insert_one(address_with_id)
         return inserted_address.inserted_id
 
-    def _cursor_properties(self, cursor_timeout_millis=None) -> Dict:
+    def _cursor_properties(self, cursor_timeout_millis: int = None) -> Dict:
         return (
             {"max_time_ms": cursor_timeout_millis}
             if cursor_timeout_millis


### PR DESCRIPTION
- Make more flexible deps - `ethtx` is easier to install in other apps
- No timeout for mongo cursor - some collections may sometimes require more time to search
- Cache `4bytes` resposne, if some transactions have a lot of guessed functions/events, it definitely speeds up `ethtx`!
- Fix `README` mongo string