### PR TITLE
Remove value formatting and custom mongo params 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ ethtx_config = EthTxConfig(
 )
 
 ethtx = EthTx.initialize(ethtx_config)
-transaction: DecodedTransaction = ethtx.decoders.decode_transaction(
+decoded_transaction: DecodedTransaction = ethtx.decoders.decode_transaction(
     '0x50051e0a6f216ab9484c2080001c7e12d5138250acee1f4b7c725b8fb6bb922d')
 ```
 

--- a/ethtx/decoders/decoder_service.py
+++ b/ethtx/decoders/decoder_service.py
@@ -35,7 +35,9 @@ class DecoderService:
         self.web3provider: NodeDataProvider = web3provider
         self.default_chain: str = default_chain
 
-    def decode_transaction(self, chain_id: str, tx_hash: str, recreate_semantics: bool = False) -> DecodedTransaction:
+    def decode_transaction(
+        self, chain_id: str, tx_hash: str, recreate_semantics: bool = False
+    ) -> DecodedTransaction:
 
         # verify the transaction hash
         tx_hash = tx_hash if tx_hash.startswith("0x") else "0x" + tx_hash
@@ -82,7 +84,6 @@ class DecoderService:
         if recreate_semantics:
             self.semantic_decoder.repository.delete_semantics(chain_id, used_semantics)
             return self.decode_transaction(chain_id, tx_hash, False)
-
 
         return semantically_decoded_tx
 

--- a/ethtx/decoders/semantic/transfers.py
+++ b/ethtx/decoders/semantic/transfers.py
@@ -34,7 +34,4 @@ class SemanticTransfersDecoder(SemanticSubmoduleAbc):
                 tx_metadata.receiver.address,
             )
 
-            # format the transfer value
-            transfer.value = float(f"{transfer.value:,.4f}")
-
         return transfers

--- a/ethtx/providers/semantic_providers/repository.py
+++ b/ethtx/providers/semantic_providers/repository.py
@@ -31,7 +31,6 @@ from ethtx.semantics.protocols_router import amend_contract_semantics
 from ethtx.semantics.solidity.precompiles import precompiles
 from ethtx.semantics.standards.erc20 import ERC20_FUNCTIONS, ERC20_EVENTS
 from ethtx.semantics.standards.erc721 import ERC721_FUNCTIONS, ERC721_EVENTS
-from ethtx.utils.cache_tools import cache
 
 
 class SemanticsRepository:
@@ -468,6 +467,6 @@ class SemanticsRepository:
         else:
             self.database.insert_signature(signature=signature.dict())
 
-    def delete_semantics(self, chain_id:str, addresses: List[str]):
+    def delete_semantics(self, chain_id: str, addresses: List[str]):
         for address in addresses:
             self.database.delete_semantics_by_address(chain_id, address)


### PR DESCRIPTION
- Removed support for optional parameters in mongo, due to different tiers of atlas.
- Removed the formatting of `transfer.value`, so the value remains unchanged
- Renamed a variable in `README.md` 
- `black` formatting