### PR TITLE
Fix broken dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,7 +15,7 @@ eth-utils = "==1.10.0"
 eth-rlp = "==0.2.1"
 pydantic = ">=1.8.0"
 python-dotenv = "*"
-requests_cache = "*"
+requests-cache = "!=0.9.5"
 
 [dev-packages]
 black = "*"


### PR DESCRIPTION
Updated `requests-cache` version. Pipenv could not handle the bad dependencies in this package!