### PR TITLE
bugfix: Link Balance Calculated Incorrectly

### DIFF
--- a/ethtx/providers/semantic_providers/repository.py
+++ b/ethtx/providers/semantic_providers/repository.py
@@ -33,7 +33,7 @@ from ethtx.providers.semantic_providers.database import ISemanticsDatabase
 from ethtx.providers.web3_provider import NodeDataProvider
 from ethtx.semantics.protocols_router import amend_contract_semantics
 from ethtx.semantics.solidity.precompiles import precompiles
-from ethtx.semantics.standards.erc20 import ERC20_FUNCTIONS, ERC20_EVENTS
+from ethtx.semantics.standards.erc20 import ERC20_FUNCTIONS, ERC20_EVENTS, ERC20_MODIFIED_EVENTS
 from ethtx.semantics.standards.erc721 import ERC721_FUNCTIONS, ERC721_EVENTS
 
 
@@ -211,7 +211,7 @@ class SemanticsRepository:
         if not address:
             return standard, standard_semantics
 
-        if all(erc20_event in events for erc20_event in ERC20_EVENTS) and all(
+        if (all(erc20_event in events for erc20_event in ERC20_EVENTS) or all(erc20_event in events for erc20_event in ERC20_MODIFIED_EVENTS)) and all(
             erc20_function in functions for erc20_function in ERC20_FUNCTIONS
         ):
             standard = "ERC20"

--- a/ethtx/semantics/standards/erc20.py
+++ b/ethtx/semantics/standards/erc20.py
@@ -38,6 +38,26 @@ erc20_transfer_event = EventSemantics(
     ],
 )
 
+erc20_modified_transfer_event = EventSemantics(
+    signature="0xe19260aff97b920c7df27010903aeb9c8d2be5d310a2c67824cf3f15396e4c16",
+    anonymous=False,
+    name="Transfer",
+    parameters=[
+        ParameterSemantics(
+            parameter_name="src", parameter_type="address", indexed=True
+        ),
+        ParameterSemantics(
+            parameter_name="dst", parameter_type="address", indexed=True
+        ),
+        ParameterSemantics(
+            parameter_name="value", parameter_type="uint256", indexed=False
+        ),
+        ParameterSemantics(
+            parameter_name="data", parameter_type="bytes", indexed=False,dynamic=True
+        ),
+    ],
+)
+
 erc20_transfer_event_transformation = {
     "__input2__": TransformationSemantics(
         transformation="__input2__ / 10**token_decimals(__contract__)"
@@ -144,6 +164,11 @@ erc20_totalSupply_function_transformation = {
 
 ERC20_EVENTS = {
     erc20_transfer_event.signature: erc20_transfer_event,
+    erc20_approval_event.signature: erc20_approval_event,
+}
+
+ERC20_MODIFIED_EVENTS = {
+    erc20_modified_transfer_event.signature: erc20_modified_transfer_event,
     erc20_approval_event.signature: erc20_approval_event,
 }
 


### PR DESCRIPTION
Link emits a different transfer event than normal erc20s so we miscalculate the balance. This adds in listening for that event.

Random Link event chosen for test case:
0xbaf08c360fc8f6098adbe2c7c3612106432123397dd2d5b84d042c1786261207

Previous result:
<img width="451" alt="Screenshot 2023-08-11 at 6 24 05 PM" src="https://github.com/EthTx/ethtx/assets/36086914/3c6a6cac-ad40-4ed9-9247-32e431078d8f">

After change:
<img width="482" alt="Screenshot 2023-08-11 at 6 27 26 PM" src="https://github.com/EthTx/ethtx/assets/36086914/17809b8c-6af8-4d97-b085-b9b45dbb3c37">
